### PR TITLE
no longer make the exception silent if the receiving loop of a queue stops

### DIFF
--- a/source/MicroService-Core.package/MSFullQueue.class/instance/startReceiver.st
+++ b/source/MicroService-Core.package/MSFullQueue.class/instance/startReceiver.st
@@ -13,4 +13,7 @@ startReceiver
 			MSUtils logError: error.
 			Smalltalk 
 				at: #SnapDump
-				ifPresent: [ :reporter | reporter handleException: error ] ] ] forkNamed: 'queue consumer for: ', self receiverQueue asString.
+				ifPresent: [ :reporter | reporter handleException: error ].
+			"we want to let the exception pass so that users can be notified that the receiving loop stopped"
+			error pass.	
+			 ] ] forkNamed: 'queue consumer for: ', self receiverQueue asString.


### PR DESCRIPTION
I am not sure we already faced this case,
but by looking at the code I thought that if we had to face it,
we would rather not make the exception silent.

If this change is accepted, would it be possible to tag a new 0.12 version ?
so that we can reference it from our baseline and have the code running for our next release

