### PR TITLE
Fork the snap dump reporting when the loop break

### DIFF
--- a/source/MicroService-Core.package/MSFullQueue.class/instance/runLoop.st
+++ b/source/MicroService-Core.package/MSFullQueue.class/instance/runLoop.st
@@ -21,6 +21,8 @@ runLoop
 			MSUtils logError: err messageText.
 			Smalltalk
 				at: #SnapDump
-				ifPresent: [ :cls | cls handleException: err ] ].
+				ifPresent: [ :cls | 
+				"fork so that it does not block the auto-restart of the loop."	
+				[cls handleException: err] fork ] ].
 	self resetReceiver.
 	MSUtils logDebug: 'restarting runLoop' ] repeat


### PR DESCRIPTION
so that the auto-restart remains  immediate  and is not delayed by this process

Here is case we experimented:

The api image got the “ZnIncomplete” error and the queue went down (not sure about the order). 
SnapDump intercepted the error and tried to report.



```
2019-08-02 15:53:29 849 Connection Established snapshots.2denker.de:443 94.130.137.118 14ms 
2019-08-02 15:53:29 850 Request Written a ZnRequest(HEAD /api/snapshots/f5504546f7a200ed4a4fdc25e80d33a42ca6e738de39c4072c2a8d0ed456b1d3) 0ms
2019-08-02 15:53:29 851 Response Read a ZnResponse(404 Not Found) 3ms
2019-08-02 15:53:29 852 HEAD /api/snapshots/f5504546f7a200ed4a4fdc25e80d33a42ca6e738de39c4072c2a8d0ed456b1d3 404 3ms
```

. 
While snap dump is reporting the error, the “auto restart” mechanism of the receiving loop is “blocked”, waiting for the error to be reported. 
But snap dump took a lot of a time to report and even seemed to get an error.

```
2019-08-02 16:24:46 929 Request Written a ZnRequest(PUT /api/snapshots/f5504546f7a200ed4a4fdc25e80d33a42ca6e738de39c4072c2a8d0ed456b1d3) 1228ms
2019-08-02 16:24:46 930 Response Read a ZnResponse(400 Bad Request text/plain;charset=utf-8 30B) 17ms
2019-08-02 16:24:46 931 PUT /api/snapshots/f5504546f7a200ed4a4fdc25e80d33a42ca6e738de39c4072c2a8d0ed456b1d3 400 30B 1245ms
2019-08-02 16:24:46 932 Connection Closed 94.130.137.118:443SnapDump: Error reporting gave response: Bad Request ZnEntityTooLarge
```

One reason could be that the stack being reported is very big. 
Big enough to exceed the default uplaod limit of zinc.
As soon as we got the snap dump error, the queue restarted, and the pharo image was able again to get responses from broker.

Even if the stack would be big, it still feel suspicious that the image took half an our to try uploading it.
Maybe there was other things going wrong within the image.
But I think It does not hurt to at least "free" the receiving loop.