### PR TITLE
set back version 0.1 of metrics.

### DIFF
--- a/source/BaselineOfMicroService.package/BaselineOfMicroService.class/instance/baseline..st
+++ b/source/BaselineOfMicroService.package/BaselineOfMicroService.class/instance/baseline..st
@@ -17,7 +17,7 @@ baseline: spec
 							
 			baseline: 'Metrics' with: [ 
 				 spec 
-					repository: 'github://zweidenker/pharo-metrics:0.2/source'];
+					repository: 'github://zweidenker/pharo-metrics:0.1/source'];
 				
 			baseline: 'NeoJSON' with: [ 
 				spec 


### PR DESCRIPTION
while moving to the next version, we should also adapt some pieces of code:
- startup scripts
- pharo-micro-service metric handler

My intention is to first fix alpha that can’t be deployed anymore.

When having back a stable alpha, work again on the metrics version upgrade