### PR TITLE
Make error handling consistent for all local handlers

### DIFF
--- a/source/MicroService-Core.package/MSDirectHandler.class/instance/sendAsyncRequest..st
+++ b/source/MicroService-Core.package/MSDirectHandler.class/instance/sendAsyncRequest..st
@@ -1,6 +1,0 @@
-accessing
-sendAsyncRequest: aRequest
-	MMUtils logDebug: 'sending async future ' , aRequest asString .
-	^ [ self handleRequest: aRequest. ] future.
-
-	

--- a/source/MicroService-Core.package/MSLocalHandler.class/instance/handleRequestWithErrors..st
+++ b/source/MicroService-Core.package/MSLocalHandler.class/instance/handleRequestWithErrors..st
@@ -1,0 +1,10 @@
+accessing
+handleRequestWithErrors: aRequest
+	| response |
+	response := self handleRequest: aRequest.
+	response isError
+		ifTrue: [ 
+			"no need for snap dump report here.
+			it is the responsibility of the request initiator to handle the exception properly "
+			response signal ].
+	^ response

--- a/source/MicroService-Core.package/MSLocalHandler.class/instance/sendAsyncRequest..st
+++ b/source/MicroService-Core.package/MSLocalHandler.class/instance/sendAsyncRequest..st
@@ -1,11 +1,4 @@
 accessing
 sendAsyncRequest: aRequest
 	MMUtils logDebug: 'sending async request ' , aRequest asString .
-	 ^  [ | response |
-		response := self handleRequest: aRequest.
-		response isError ifTrue: [
-			Smalltalk  
-					at: #SnapDump
-					ifPresent: [ :reporter | reporter handleException: response ]. 
-			response signal ].
-		response ] future
+	 ^  [ self handleRequestWithErrors: aRequest] future

--- a/source/MicroService-Core.package/MSLocalHandler.class/instance/sendAsyncRequest..st
+++ b/source/MicroService-Core.package/MSLocalHandler.class/instance/sendAsyncRequest..st
@@ -1,5 +1,6 @@
 accessing
 sendAsyncRequest: aRequest
+	MMUtils logDebug: 'sending async request ' , aRequest asString .
 	 ^  [ | response |
 		response := self handleRequest: aRequest.
 		response isError ifTrue: [
@@ -8,6 +9,3 @@ sendAsyncRequest: aRequest
 					ifPresent: [ :reporter | reporter handleException: response ]. 
 			response signal ].
 		response ] future
-	
-	
-	

--- a/source/MicroService-Core.package/MSLocalHandler.class/instance/sendSyncRequest..st
+++ b/source/MicroService-Core.package/MSLocalHandler.class/instance/sendSyncRequest..st
@@ -1,7 +1,4 @@
 accessing
 sendSyncRequest: aRequest
-	| response |
-	response := self handleRequest: aRequest.
-	response isError ifTrue: [ 
-		response signal ].
-	^ response
+	MMUtils logDebug: 'sending sync request ' , aRequest asString .
+	^ self handleRequestWithErrors: aRequest


### PR DESCRIPTION
Bug spotted with snapdump.
When using a MSDirectHandler, micro-services error responses are not signaled. 
But deployed successfully and passed to the future resolution block.

I made all kind of local handler raise an error if they receive an error response.
Howerver, I realize that there is now no difference between MSDIrectHandler and MSTaskItHandler.
So I wonder what was the initial intention for having 2 separate classes ?
Did we intentionally wanted to have a handler that does not "raise" micro service errors ?
